### PR TITLE
Fix#23: Mark hpo as inactive if it stopped

### DIFF
--- a/python/naiveautoml/naiveautoml.py
+++ b/python/naiveautoml/naiveautoml.py
@@ -331,9 +331,9 @@ class NaiveAutoML:
                         if score > self.best_score_overall:
                             self.best_score_overall = score
                         self.history.append({"time": time.time() - self.start_time, "pl": str(pl), "score_internal": score, "scores": scores, "new_best": score > self.best_score_overall})
-                        if not hpo.active:
-                            self.logger.info(f"Deactivating {name}")
-                            inactive.append(name)
+                    if not hpo.active:
+                        self.logger.info(f"Deactivating {name}")
+                        inactive.append(name)
                 except KeyboardInterrupt:
                     raise
                 except Exception as e:


### PR DESCRIPTION
When early stopping is triggered [here](https://github.com/fmohr/naiveautoml/blob/a7f4a35831f316aed4c7f38bfe4d396819fff46c/python/naiveautoml/commons.py#L1099C4-L1102), no result is returned. This means that the check to see if `not hpo.active` is also skipped. The next time `step` is invoked on the object, it returns an error. Dedenting the check correctly checks whether or not `hpo` is active after each call, preventing it from being `step`ped after it stopped early.